### PR TITLE
allow route matching to find the route even if a dynamic page exists …

### DIFF
--- a/packages/core/src/server/utilities/next.ts
+++ b/packages/core/src/server/utilities/next.ts
@@ -37,7 +37,7 @@ export function resolvePathname(nextServer: NextNodeServer, pathname: string) {
     ...nextServer.getAppPathRoutes(),
   };
 
-  for (const [key, [path]] of Object.entries(appRoutes)) {
+  outer: for (const [key, [path]] of Object.entries(appRoutes)) {
     const hasDynamic = key.includes('[') && key.includes(']');
 
     if (hasDynamic) {
@@ -53,7 +53,7 @@ export function resolvePathname(nextServer: NextNodeServer, pathname: string) {
         if (keyParts[i] !== pathParts[i]) break;
 
         if (i === keyParts.length - 1) {
-          if (!path?.endsWith('/route')) return null;
+          if (!path?.endsWith('/route')) continue outer;
           return path;
         }
       }


### PR DESCRIPTION
…with a potentially matching segment

If a user has an app dreictory that looks something like this:

  [something]/page.tsx
  websocket/route.ts

next-ws would not have detected websocket as viable route and would have faild to allow the websocket connection