### PR TITLE
bumped patch version for next 14.2.13

### DIFF
--- a/packages/cli/src/patches/patch-3.ts
+++ b/packages/cli/src/patches/patch-3.ts
@@ -35,6 +35,6 @@ export default Object.assign(
   },
   {
     date: '2023-11-01' as const,
-    supported: '>=13.5.1 <=14.2.4' as const,
+    supported: '>=13.5.1 <=14.2.13' as const,
   },
 );


### PR DESCRIPTION
I've tested it locally and it works with the latest version of `next`, so I think patch version can be safely bumped.