### PR TITLE
Bumped patch-3 supported version to include NextJS 15.0.4

### DIFF
--- a/packages/cli/src/patches/patch-3.ts
+++ b/packages/cli/src/patches/patch-3.ts
@@ -36,6 +36,6 @@ export default Object.assign(
   },
   {
     date: '2023-11-01' as const,
-    supported: '>=13.5.1 <=15.0.1' as const,
+    supported: '>=13.5.1 <=15.0.4' as const,
   },
 );


### PR DESCRIPTION
nextjs 15.0.4 has been released - https://github.com/vercel/next.js/releases/tag/v15.0.4