### PR TITLE
Bumped patch-3 supported version

### DIFF
--- a/packages/cli/src/patches/patch-3.ts
+++ b/packages/cli/src/patches/patch-3.ts
@@ -36,6 +36,6 @@ export default Object.assign(
   },
   {
     date: '2023-11-01' as const,
-    supported: '>=13.5.1 <=15.0.1' as const,
+    supported: '>=13.5.1 <=15.1.3' as const,
   },
 );

--- a/packages/cli/src/patches/patch-3.ts
+++ b/packages/cli/src/patches/patch-3.ts
@@ -36,6 +36,6 @@ export default Object.assign(
   },
   {
     date: '2023-11-01' as const,
-    supported: '>=13.5.1 <=15.1.3' as const,
+    supported: '>=13.5.1 <=15.1.4' as const,
   },
 );


### PR DESCRIPTION
nextjs 15.1.3 has been released - https://github.com/vercel/next.js/releases/tag/v15.1.3

Trying again after https://github.com/apteryxxyz/next-ws/pull/51. This update allows React 19 to be used.