### PR TITLE
Add request async storage for upgrade handlers

### DIFF
--- a/.changeset/true-onions-call.md
+++ b/.changeset/true-onions-call.md
@@ -1,0 +1,5 @@
+---
+"next-ws": minor
+---
+
+Add request async storage for upgrade handlers

--- a/examples/base-path/app/(simple)/api/ws/route.ts
+++ b/examples/base-path/app/(simple)/api/ws/route.ts
@@ -1,3 +1,5 @@
+import { headers } from 'next/headers';
+
 export function GET() {
   const headers = new Headers();
   headers.set('Connection', 'Upgrade');
@@ -5,10 +7,14 @@ export function GET() {
   return new Response('Upgrade Required', { status: 426, headers });
 }
 
-export function UPGRADE(
+export async function UPGRADE(
   client: import('ws').WebSocket,
   server: import('ws').WebSocketServer,
 ) {
+  // For testing purposes
+  // TODO: Make a real world use case for this
+  await headers();
+
   for (const other of server.clients) {
     if (client === other || other.readyState !== other.OPEN) continue;
     other.send(

--- a/examples/chat-room/app/(dynamic)/[code]/api/ws/route.ts
+++ b/examples/chat-room/app/(dynamic)/[code]/api/ws/route.ts
@@ -1,3 +1,5 @@
+import { headers } from 'next/headers';
+
 export function GET() {
   const headers = new Headers();
   headers.set('Connection', 'Upgrade');
@@ -5,12 +7,16 @@ export function GET() {
   return new Response('Upgrade Required', { status: 426, headers });
 }
 
-export function UPGRADE(
+export async function UPGRADE(
   client: import('ws').WebSocket,
   server: import('ws').WebSocketServer,
   _request: import('next/server').NextRequest,
   context: import('next-ws/server').RouteContext<'/[code]/api/ws'>,
 ) {
+  // For testing purposes
+  // TODO: Make a real world use case for this
+  await headers();
+
   const { code } = context.params;
 
   for (const other of server.clients) {

--- a/examples/chat-room/app/(simple)/api/ws/route.ts
+++ b/examples/chat-room/app/(simple)/api/ws/route.ts
@@ -1,3 +1,5 @@
+import { headers } from 'next/headers';
+
 export function GET() {
   const headers = new Headers();
   headers.set('Connection', 'Upgrade');
@@ -5,10 +7,14 @@ export function GET() {
   return new Response('Upgrade Required', { status: 426, headers });
 }
 
-export function UPGRADE(
+export async function UPGRADE(
   client: import('ws').WebSocket,
   server: import('ws').WebSocketServer,
 ) {
+  // For testing purposes
+  // TODO: Make a real world use case for this
+  await headers();
+
   for (const other of server.clients) {
     if (client === other || other.readyState !== other.OPEN) continue;
     other.send(

--- a/examples/custom-server/app/(dynamic)/[code]/api/ws/route.ts
+++ b/examples/custom-server/app/(dynamic)/[code]/api/ws/route.ts
@@ -1,3 +1,5 @@
+import { headers } from 'next/headers';
+
 export function GET() {
   const headers = new Headers();
   headers.set('Connection', 'Upgrade');
@@ -5,12 +7,16 @@ export function GET() {
   return new Response('Upgrade Required', { status: 426, headers });
 }
 
-export function UPGRADE(
+export async function UPGRADE(
   client: import('ws').WebSocket,
   server: import('ws').WebSocketServer,
   _request: import('next/server').NextRequest,
   context: import('next-ws/server').RouteContext<'/[code]/api/ws'>,
 ) {
+  // For testing purposes
+  // TODO: Make a real world use case for this
+  await headers();
+
   const { code } = context.params;
 
   for (const other of server.clients) {

--- a/examples/custom-server/app/(simple)/api/ws/route.ts
+++ b/examples/custom-server/app/(simple)/api/ws/route.ts
@@ -1,3 +1,5 @@
+import { headers } from 'next/headers';
+
 export function GET() {
   const headers = new Headers();
   headers.set('Connection', 'Upgrade');
@@ -5,10 +7,14 @@ export function GET() {
   return new Response('Upgrade Required', { status: 426, headers });
 }
 
-export function UPGRADE(
+export async function UPGRADE(
   client: import('ws').WebSocket,
   server: import('ws').WebSocketServer,
 ) {
+  // For testing purposes
+  // TODO: Make a real world use case for this
+  await headers();
+
   for (const other of server.clients) {
     if (client === other || other.readyState !== other.OPEN) continue;
     other.send(

--- a/src/patches/index.ts
+++ b/src/patches/index.ts
@@ -1,3 +1,4 @@
 import patch1 from './patch-1.js';
+import patch2 from './patch-2.js';
 
-export default [patch1] as const;
+export default [patch1, patch2] as const;

--- a/src/patches/patch-2.ts
+++ b/src/patches/patch-2.ts
@@ -1,0 +1,28 @@
+import { definePatch, definePatchStep } from './helpers/define.js';
+import {
+  patchCookies as p1_patchCookies,
+  patchHeaders as p1_patchHeaders,
+  patchNextNodeServer as p1_patchNextNodeServer,
+  patchRouterServer as p1_patchRouterServer,
+} from './patch-1.js';
+
+export const patchHeaders = definePatchStep({
+  ...p1_patchHeaders,
+  path: 'next:dist/server/request/headers.js',
+});
+
+export const patchCookies = definePatchStep({
+  ...p1_patchCookies,
+  path: 'next:dist/server/request/cookies.js',
+});
+
+export default definePatch({
+  name: 'patch-2',
+  versions: '>=15.0.0 <=15.5.0',
+  steps: [
+    p1_patchNextNodeServer,
+    p1_patchRouterServer,
+    patchHeaders,
+    patchCookies,
+  ],
+});

--- a/src/server/helpers/store.ts
+++ b/src/server/helpers/store.ts
@@ -1,0 +1,42 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { RequestCookies } from 'next/dist/compiled/@edge-runtime/cookies';
+
+class ReadonlyHeaders extends Headers {
+  override append(): never {
+    throw new Error('Headers are read-only');
+  }
+
+  override set(): never {
+    throw new Error('Headers are read-only');
+  }
+
+  override delete(): never {
+    throw new Error('Headers are read-only');
+  }
+}
+
+class ReadonlyRequestsCookies extends RequestCookies {
+  override set(): never {
+    throw new Error('Cookies are read-only');
+  }
+
+  override delete(): never {
+    throw new Error('Cookies are read-only');
+  }
+}
+
+export interface RequestStore {
+  readonly headers: ReadonlyHeaders;
+  readonly cookies: ReadonlyRequestsCookies;
+}
+
+export function createRequestStore(request: Request) {
+  return {
+    headers: new ReadonlyHeaders(request.headers),
+    cookies: new ReadonlyRequestsCookies(request.headers),
+  };
+}
+
+export type RequestStorage = AsyncLocalStorage<RequestStore>;
+
+export const requestStorage = new AsyncLocalStorage<RequestStore>();

--- a/src/server/persistent.ts
+++ b/src/server/persistent.ts
@@ -28,3 +28,10 @@ export const [getWebSocketServer, setWebSocketServer, useWebSocketServer] =
   useGlobal<import('ws').WebSocketServer>(
     Symbol.for('next-ws.websocket-server'),
   );
+
+// ===== Request Storage ===== //
+
+export const [getRequestStorage, setRequestStorage, useRequestStorage] = //
+  useGlobal<import('./helpers/store').RequestStorage>(
+    Symbol.for('next-ws.request-store'), //
+  );


### PR DESCRIPTION
Fixes #104
Allows for using `headers` and `cookies` in upgrade handlers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Per-request async storage for WebSocket upgrades, enabling safe access to request headers and cookies in upgrade handlers.
  - Improved compatibility across Next.js 13.5–15.5 with automatic header/cookie resolution during WebSocket contexts.
  - Example apps updated: UPGRADE handlers are now async and demonstrate reading headers.

- Chores
  - Prepared a minor release for next-ws.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->