### PR TITLE
Bump patch supported range to 15.5.2

### DIFF
--- a/.changeset/3liYSfSzv9hLT.md
+++ b/.changeset/3liYSfSzv9hLT.md
@@ -1,0 +1,5 @@
+---
+"next-ws": patch
+---
+
+Bump patch supported range to 15.5.2


### PR DESCRIPTION
Bump patch supported range to 15.5.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Prepared a patch release for the next-ws package to version 15.5.2.
  * Updated supported version range to include 15.5.2 for compatibility alignment.
  * Adjusted release metadata to reflect the new patch version.

* **Notes**
  * No functional or API changes.
  * No action required for users already on 15.5.x.
  * Safe, non-breaking update for all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->