### PR TITLE
Bump patch supported range to 15.5.2

### DIFF
--- a/.changeset/uGeKpBAjOuf2O.md
+++ b/.changeset/uGeKpBAjOuf2O.md
@@ -1,0 +1,5 @@
+---
+"next-ws": patch
+---
+
+Bump patch supported range to 15.5.2


### PR DESCRIPTION
Bump patch supported range to 15.5.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Prepared a patch release for next-ws, updating compatibility details to include version 15.5.2. This update adjusts release metadata only and does not alter functionality or interfaces.
* **Documentation**
  * Refreshed compatibility information to reflect support up to 15.5.2. No behavioural changes, configuration updates, or API modifications. No migration or user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->