### PR TITLE
Add patch step to allow UPGRADE exports from route modules

### DIFF
--- a/.changeset/mighty-icons-fold.md
+++ b/.changeset/mighty-icons-fold.md
@@ -1,0 +1,5 @@
+---
+"next-ws": patch
+---
+
+Add patch step to allow UPGRADE exports from route modules

--- a/src/patches/patch-2.ts
+++ b/src/patches/patch-2.ts
@@ -3,6 +3,7 @@ import {
   patchCookies as p1_patchCookies,
   patchHeaders as p1_patchHeaders,
   patchNextNodeServer as p1_patchNextNodeServer,
+  patchNextTypesPlugin as p1_patchNextTypesPlugin,
   patchRouterServer as p1_patchRouterServer,
 } from './patch-1.js';
 
@@ -24,6 +25,7 @@ export default definePatch({
   steps: [
     p1_patchNextNodeServer,
     p1_patchRouterServer,
+    p1_patchNextTypesPlugin,
     patchHeaders,
     patchCookies,
   ],


### PR DESCRIPTION
Closes #124
Closes #125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Route modules now support exporting UPGRADE and SOCKET HTTP methods, enabling upgrade/WebSocket handlers without type errors.
  - Patch sequence updated to ensure this support is applied consistently across build configurations.

- Chores
  - Prepared a patch release for next-ws documenting the new capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->