### PR TITLE
Bump patch supported range to 15.5.3

### DIFF
--- a/.changeset/LTtYmiKBKhEfO.md
+++ b/.changeset/LTtYmiKBKhEfO.md
@@ -1,0 +1,5 @@
+---
+"next-ws": patch
+---
+
+Bump patch supported range to 15.5.3


### PR DESCRIPTION
Bump patch supported range to 15.5.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated release versioning to support patch 15.5.3 on the next-ws channel. This change affects release metadata only and does not alter features, APIs, or behaviour. Ensures compatibility labelling and distribution align with the latest patch. No action required from users; application functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->